### PR TITLE
Bug Fix: FileTransportOptions type missing lazy:boolean option (#2334)

### DIFF
--- a/lib/winston/transports/index.d.ts
+++ b/lib/winston/transports/index.d.ts
@@ -34,6 +34,7 @@ declare namespace winston {
     maxFiles?: number;
     eol?: string;
     tailable?: boolean;
+    lazy?: boolean;
   }
 
   interface FileTransportInstance extends Transport {
@@ -47,6 +48,7 @@ declare namespace winston {
     maxFiles: number | null;
     eol: string;
     tailable: boolean;
+    lazy: boolean;
 
     new(options?: FileTransportOptions): FileTransportInstance;
   }


### PR DESCRIPTION
* Test for file Transport option rotationFormat

* Test for file Transport option rotationFormat

* Added Lazy option in file transport

* Lint and test

* removed only statement

* Update test/unit/winston/transports/01-file-maxsize.test.js



* Update test/unit/winston/transports/01-file-maxsize.test.js



* Added lazy in FileTransportOptions types

* Added lazy type in FileTransportInstance

---------